### PR TITLE
Sandbox-api/Main-api chooser option

### DIFF
--- a/src/ApiHandler.php
+++ b/src/ApiHandler.php
@@ -53,8 +53,10 @@ class ApiHandler
             throw new AloPeykApiException('Invalid ACCESS-TOKEN! All AloPeyk API endpoints support the JWT authentication protocol. To start sending authenticated HTTP requests you will need to use your JWT authorization token which is sent to you. Put it in: vendor/alopeyk/alopeyk-api-php/src/Config/Configs.php : TOKEN const');
         }
 
+        $url = (!!config('alopeyk.sandbox-api')) ? Configs::SANDBOX_URL : Configs::API_URL;
+
         $curlOptions = [
-            CURLOPT_URL => Configs::API_URL . $endPoint,
+            CURLOPT_URL => $url . $endPoint,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_ENCODING => '',
             CURLOPT_MAXREDIRS => 10,

--- a/src/Config/Configs.php
+++ b/src/Config/Configs.php
@@ -12,6 +12,7 @@ class Configs
     | Don't edit following values
     |
     */
+    const SANDBOX_URL = 'https://sandbox-api.alopeyk.com/api/v2/';
     const API_URL = 'https://api.alopeyk.com/api/v2/';
     const ADDRESS_TYPES = [
         'origin',

--- a/src/Config/alopeyk.php
+++ b/src/Config/alopeyk.php
@@ -13,4 +13,17 @@ return [
 
     'access-token' => "PUT-YOUR-ACCESS-TOKEN-HERE",
 
+    /*
+    |--------------------------------------------------------------------------
+    | API SANDBOX-API
+    |--------------------------------------------------------------------------
+    |
+    | This value determines that you'r using api in an experimental
+    | environment called sandbox or using it in operational one.
+    | If disabled, requests sends to operational api server.
+    |
+    */
+
+    'sandbox-api' => true,
+
 ];


### PR DESCRIPTION
This update adds an option to the package, which allows users to switch between the sandbox-api and the main one.
This is done by changing the sandbox-api attribute in the configuration file by users.